### PR TITLE
Add a DOCTYPE to make it a valid HTML5 Document

### DIFF
--- a/src/lib/pages.ts
+++ b/src/lib/pages.ts
@@ -323,7 +323,7 @@ export const buildPages = async (
             }
 
             const htmlPath = path.join(toPath, routePath, 'index.html')
-            await fse.outputFile(htmlPath, document.toString())
+            await fse.outputFile(htmlPath, `<!DOCTYPE html>\n${document.toString()}`)
 
             if (!pagesCache[cacheKey].routePaths.includes(htmlPath)) {
                 pagesCache[cacheKey].routePaths.push(htmlPath)


### PR DESCRIPTION
I noticed some strange rendering-differences compared to other generators and was looking for the reason.
I saw there is no `<!DOCTYPE html>` at the beginning of the HTML to make it a valid HTML5 document. 

This is basically a «breaking» change, since it can change the look of a page.
 
For reference, see [HTML5 Spec](https://html.spec.whatwg.org/multipage/syntax.html#the-doctype)